### PR TITLE
Enable PDF Build

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -57,7 +57,7 @@
       "Pdf"
     ]
   },
-  "need_generate_pdf_url_template": false,
+  "need_generate_pdf_url_template": true,
   "need_generate_intellisense": false,
   "Targets": {
     "Pdf": {


### PR DESCRIPTION
# การสนับสนุนแบบสาธารณะยังไม่ได้รับการยอมรับในขณะนี้

ที่เก็บนี้เปิดให้เป็นสาธารณะเพื่ออำนวยความสะดวกในการดาวน์โหลดและเพื่อใช้งานเนื้อหานี้สำหรับสร้างโซลูชันวิธีใช้แบบกำหนดเอง
ขณะนี้เรายังไม่รับการสนับสนุนแบบสาธารณะไปยังที่เก็บนี้หรือเนื้อหานี้
หากคุณต้องการให้การสนับสนุนในเนื้อหาที่เผยแพร่ของ Microsoft โปรดไปที่ที่เก็บเวอร์ชันภาษาอังกฤษที่กำลังประมวลผลการสนับสนุนแบบสาธารณะ
